### PR TITLE
Send original SPARQL query string to endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
             **/node_modules
             .rdf-test-suite-cache
             .rdf-test-suite-ldf-cache
-          key: ${{ runner.os }}-test-modules-v1-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-test-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         run: yarn install --pure-lockfile
       - name: Build project
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-lint-modules-v1-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-lint-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         run: yarn install --pure-lockfile
       - name: Run linter
@@ -90,7 +90,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-browser-modules-v1-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-browser-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         run: yarn install --pure-lockfile
       - name: Build for browser
@@ -117,7 +117,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-docker-modules-v1-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-docker-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         run: yarn install --pure-lockfile
       - name: Install Lerna Docker
@@ -147,7 +147,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-docs-modules-v1-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-docs-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         run: yarn install --pure-lockfile
       - name: Build docs

--- a/packages/actor-init-sparql/lib/ActorInitSparql-browser.ts
+++ b/packages/actor-init-sparql/lib/ActorInitSparql-browser.ts
@@ -182,6 +182,8 @@ export class ActorInitSparql extends ActorInit implements IActorInitSparqlArgs, 
     // Parse query
     let operation: Algebra.Operation;
     if (typeof query === 'string') {
+      // Save the original query string in the context
+      context = context.set(KeysInitSparql.queryString, query);
       const queryParseOutput = await this.mediatorSparqlParse.mediate({ context, query, queryFormat, baseIRI });
       operation = queryParseOutput.operation;
       // Update the baseIRI in the context if the query modified it.

--- a/packages/actor-query-operation-service/lib/ActorQueryOperationService.ts
+++ b/packages/actor-query-operation-service/lib/ActorQueryOperationService.ts
@@ -34,10 +34,10 @@ export class ActorQueryOperationService extends ActorQueryOperationTypedMediated
     context = context || ActionContext({});
     let subContext: ActionContext = context
       .delete(KeysRdfResolveQuadPattern.source)
-      .delete(KeysRdfResolveQuadPattern.sources);
+      .delete(KeysRdfResolveQuadPattern.sources)
+      .delete(KeysInitSparql.queryString);
     const sourceType = this.forceSparqlEndpoint ? 'sparql' : undefined;
     subContext = subContext.set(KeysRdfResolveQuadPattern.sources, [{ type: sourceType, value: endpoint }]);
-    subContext = subContext.delete(KeysInitSparql.queryString);
     // Query the source
     let output: IActorQueryOperationOutputBindings;
     try {

--- a/packages/actor-query-operation-service/lib/ActorQueryOperationService.ts
+++ b/packages/actor-query-operation-service/lib/ActorQueryOperationService.ts
@@ -1,7 +1,7 @@
 import type { IActorQueryOperationTypedMediatedArgs } from '@comunica/bus-query-operation';
 import { ActorQueryOperation, ActorQueryOperationTypedMediated,
   Bindings } from '@comunica/bus-query-operation';
-import { KeysRdfResolveQuadPattern } from '@comunica/context-entries';
+import { KeysInitSparql, KeysRdfResolveQuadPattern } from '@comunica/context-entries';
 import type { IActorTest } from '@comunica/core';
 import { ActionContext } from '@comunica/core';
 import type { IActorQueryOperationOutputBindings } from '@comunica/types';
@@ -37,7 +37,7 @@ export class ActorQueryOperationService extends ActorQueryOperationTypedMediated
       .delete(KeysRdfResolveQuadPattern.sources);
     const sourceType = this.forceSparqlEndpoint ? 'sparql' : undefined;
     subContext = subContext.set(KeysRdfResolveQuadPattern.sources, [{ type: sourceType, value: endpoint }]);
-
+    subContext = subContext.delete(KeysInitSparql.queryString);
     // Query the source
     let output: IActorQueryOperationOutputBindings;
     try {

--- a/packages/actor-query-operation-sparql-endpoint/lib/ActorQueryOperationSparqlEndpoint.ts
+++ b/packages/actor-query-operation-sparql-endpoint/lib/ActorQueryOperationSparqlEndpoint.ts
@@ -73,7 +73,7 @@ export class ActorQueryOperationSparqlEndpoint extends ActorQueryOperation {
 
   public async run(action: IActionQueryOperation): Promise<IActorQueryOperationOutput> {
     const source = await DataSourceUtils.getSingleSource(action.context);
-    if (!source) {
+    if (!action.context || !source) {
       throw new Error('Illegal state: undefined sparql endpoint source.');
     }
     const endpoint: string = <string> getDataSourceValue(source);
@@ -86,7 +86,7 @@ export class ActorQueryOperationSparqlEndpoint extends ActorQueryOperation {
     let variables: RDF.Variable[] | undefined;
     try {
       // Use the original query string if available
-      query = action.context?.get(KeysInitSparql.queryString) ?? toSparql(action.operation);
+      query = action.context.get(KeysInitSparql.queryString) ?? toSparql(action.operation);
       // This will throw an error in case the result is an invalid SPARQL query
       type = this.endpointFetcher.getQueryType(query);
 

--- a/packages/actor-query-operation-sparql-endpoint/lib/ActorQueryOperationSparqlEndpoint.ts
+++ b/packages/actor-query-operation-sparql-endpoint/lib/ActorQueryOperationSparqlEndpoint.ts
@@ -6,6 +6,7 @@ import {
 } from '@comunica/bus-query-operation';
 import { getDataSourceType, getDataSourceValue } from '@comunica/bus-rdf-resolve-quad-pattern';
 import { getDataDestinationType, getDataDestinationValue } from '@comunica/bus-rdf-update-quads';
+import { KeysInitSparql } from '@comunica/context-entries';
 import type { ActionContext, Actor, IActorArgs, IActorTest, Mediator } from '@comunica/core';
 import type { IMediatorTypeHttpRequests } from '@comunica/mediatortype-httprequests';
 import type { IActionQueryOperation,
@@ -80,11 +81,12 @@ export class ActorQueryOperationSparqlEndpoint extends ActorQueryOperation {
 
     // Determine the full SPARQL query that needs to be sent to the endpoint
     // Also check the type of the query (SELECT, CONSTRUCT (includes DESCRIBE) or ASK)
-    let query: string | undefined;
+    let query: string;
     let type: 'SELECT' | 'CONSTRUCT' | 'ASK' | 'UNKNOWN' | IUpdateTypes | undefined;
     let variables: RDF.Variable[] | undefined;
     try {
-      query = toSparql(action.operation);
+      // Use the original query string if available
+      query = action.context?.get(KeysInitSparql.queryString) ?? toSparql(action.operation);
       // This will throw an error in case the result is an invalid SPARQL query
       type = this.endpointFetcher.getQueryType(query);
 

--- a/packages/actor-query-operation-sparql-endpoint/package.json
+++ b/packages/actor-query-operation-sparql-endpoint/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
     "@comunica/bus-rdf-update-quads": "^1.22.2",
+    "@comunica/context-entries": "^1.22.0",
     "@comunica/types": "^1.22.0",
     "@comunica/utils-datasource": "^1.22.2",
     "@rdfjs/types": "*",

--- a/packages/actor-query-operation-sparql-endpoint/test/ActorQueryOperationSparqlEndpoint-test.ts
+++ b/packages/actor-query-operation-sparql-endpoint/test/ActorQueryOperationSparqlEndpoint-test.ts
@@ -381,5 +381,22 @@ this is a body`));
         return actor.run(op).then(async output => (<any> output).bindingsStream.on('error', resolve));
       })).resolves.toEqual(new Error('MY ERROR'));
     });
+
+    it('should run using the original query string in the context if one exists', async() => {
+      const context = ActionContext({
+        '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'sparql', value: 'http://example.org/sparql-select' },
+        '@comunica/actor-init-sparql:queryString': 'SELECT ?myP WHERE { <http://s> ?p <http://o>. }',
+      });
+      const op: any = { context,
+        operation: factory.createPattern(DF.namedNode('http://s'), DF.variable('p'), DF.namedNode('http://o')) };
+      const output: IActorQueryOperationOutputBindings = <any> await actor.run(op);
+      expect(await (<any> output).metadata()).toEqual({ totalItems: 3 });
+
+      expect(await arrayifyStream(output.bindingsStream)).toEqual([
+        Bindings({ '?p': DF.namedNode('http://example.org/sparql-selectPOSTquery=SELECT+%3FmyP+WHERE+%7B+%3Chttp%3A%2F%2Fs%3E+%3Fp+%3Chttp%3A%2F%2Fo%3E.+%7D/1') }),
+        Bindings({ '?p': DF.namedNode('http://example.org/sparql-selectPOSTquery=SELECT+%3FmyP+WHERE+%7B+%3Chttp%3A%2F%2Fs%3E+%3Fp+%3Chttp%3A%2F%2Fo%3E.+%7D/2') }),
+        Bindings({ '?p': DF.namedNode('http://example.org/sparql-selectPOSTquery=SELECT+%3FmyP+WHERE+%7B+%3Chttp%3A%2F%2Fs%3E+%3Fp+%3Chttp%3A%2F%2Fo%3E.+%7D/3') }),
+      ]);
+    });
   });
 });

--- a/packages/context-entries/lib/Keys.ts
+++ b/packages/context-entries/lib/Keys.ts
@@ -52,6 +52,10 @@ export enum KeysInitSparql {
    */
   lenient = '@comunica/actor-init-sparql:lenient',
   /**
+   * @range {string} The original query string.
+   */
+  queryString = '@comunica/actor-init-sparql:queryString',
+  /**
    * @range {Algebra.Operation} The original parsed query.
    */
   query = '@comunica/actor-init-sparql:query',


### PR DESCRIPTION
This is in an initial attempt to solve https://github.com/comunica/comunica/issues/844.

As suggested in the issue description, in `actor-init-sparql` we save the original query string in the context, and in `actor-query-operation-sparql-endpoint`, we check this context entry and use it if it exists.

### Questions

1. I've added `@comunica/context-entries` to the dependencies in `actor-query-operation-sparql-endpoint/package.json`, but running `yarn run lint` produces the following error:

> workspace/comunica/packages/actor-query-operation-sparql-endpoint/lib/ActorQueryOperationSparqlEndpoint.ts
  9:1  error  '@comunica/context-entries' should be listed in the project's dependencies. Run 'npm i -S @comunica/context-entries' to add it  import/no-extraneous-dependencies

Is there something else I need to do?  Also, do I need to update the version of `@comunica/context-entries` to reflect the addition of the new key?

2. How should I go about testing`ActorQueryOperationSparqlEndpoint.ts`?  I've added one additional test to attempt to test the new functionality added in line 89, but the test output says that both branches of this line are not covered.

3.  The issue description states that "we have to make sure that this context entry does not propagate to places where it shouldn't" and suggests "making sure that the service operator unsets or overrides this entry".  Are there any other places that we need to do this besides the service operator?